### PR TITLE
Update: 上下左右の移動の際のシャチのモデルも傾けるように

### DIFF
--- a/Assets/Scenes/MainScene/MainGameScene.unity
+++ b/Assets/Scenes/MainScene/MainGameScene.unity
@@ -339,6 +339,10 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6728069184010230408, guid: fc261228868bf4244a3c6aa1c321cfe0, type: 3}
+      propertyPath: m_ApplyRootMotion
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7254962440931113416, guid: fc261228868bf4244a3c6aa1c321cfe0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 3.61

--- a/Assets/Scenes/MainScene/move.cs
+++ b/Assets/Scenes/MainScene/move.cs
@@ -40,11 +40,23 @@ public class Move : MonoBehaviour
         HandleThrow();
         if (Input.GetKey(KeyCode.W)) vertical += 1f;
         if (Input.GetKey(KeyCode.S)) vertical -= 1f;
-        if (Input.GetKey(KeyCode.A) || SerialReceive.pitchAngle <= -60) horizontal -= 1f;
-        if (Input.GetKey(KeyCode.D) || SerialReceive.pitchAngle >= 60) horizontal += 1f;
+        if (Input.GetKey(KeyCode.A) || SerialReceive.pitchAngle <= -60){
+            horizontal -= 1f;
+            orca.transform.localRotation = Quaternion.Euler(0, 0, -SerialReceive.pitchAngle);
+        }
+        if (Input.GetKey(KeyCode.D) || SerialReceive.pitchAngle >= 60) {
+            horizontal += 1f;
+            orca.transform.localRotation = Quaternion.Euler(0, 0, -SerialReceive.pitchAngle);
+        }
 
-        if (Input.GetKey(KeyCode.UpArrow) || SerialReceive.rollAngle >= 35) upDown += 1f;
-        if (Input.GetKey(KeyCode.DownArrow) || SerialReceive.rollAngle <= -35) upDown -= 1f;
+        if (Input.GetKey(KeyCode.UpArrow) || SerialReceive.rollAngle >= 35) {
+            upDown += 1f;
+            orca.transform.localRotation = Quaternion.Euler(-SerialReceive.rollAngle, 0, 0);
+        }
+        if (Input.GetKey(KeyCode.DownArrow) || SerialReceive.rollAngle <= -35) {
+            upDown -= 1f;
+            orca.transform.localRotation = Quaternion.Euler(-SerialReceive.rollAngle, 0, 0);
+        }
 
         Vector3 direction = new Vector3(horizontal, upDown, vertical).normalized;
         // 斜方投射中は通常移動を無効化


### PR DESCRIPTION
https://github.com/user-attachments/assets/d1ba6179-dba3-4acd-bf56-26ad664a2b08

↑こんな感じです。
これが正常に動作するには、M5という文字が書かれた側をシャチの浮き輪の尻尾の側になるようにスティックを取り付けます。